### PR TITLE
Avoid duplicate alerts

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,7 +1,5 @@
 name: "My CodeQL config"
 
-disable-default-queries: true
-
 queries:
   - uses: ./src
 


### PR DESCRIPTION
UI5 dataflow queries are based on library ones but cannot be just extensions of standard queries because they use custom locations for sources and sinks outside of javascript code.
However, we want to avoid duplicate alerts.
This PR includes UI5-only versions of the queries as well as test cases