### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/javascript/frameworks/ui5/ext/qlpack.yml
+++ b/javascript/frameworks/ui5/ext/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-ui5-models
-version: 0.2.0
+version: 0.3.0
 extensionTargets:
   codeql/javascript-all: "^0.6.3"
   codeql/javascript-queries: "^0.6.3"

--- a/javascript/frameworks/ui5/lib/qlpack.yml
+++ b/javascript/frameworks/ui5/lib/qlpack.yml
@@ -1,9 +1,9 @@
 ---
 library: true
 name: advanced-security/javascript-sap-ui5-all
-version: 0.2.0
+version: 0.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^0.6.3"
-  advanced-security/javascript-sap-ui5-models: "^0.2.0"
+  advanced-security/javascript-sap-ui5-models: "^0.3.0"

--- a/javascript/frameworks/ui5/src/qlpack.yml
+++ b/javascript/frameworks/ui5/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-ui5-queries
-version: 0.2.0
+version: 0.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^0.6.3"
-  advanced-security/javascript-sap-ui5-models: "^0.2.0"
-  advanced-security/javascript-sap-ui5-all: "^0.2.0"
+  advanced-security/javascript-sap-ui5-models: "^0.3.0"
+  advanced-security/javascript-sap-ui5-all: "^0.3.0"
 default-suite-file: codeql-suites/sap-ui5-code-scanning.qls

--- a/javascript/frameworks/ui5/test/qlpack.yml
+++ b/javascript/frameworks/ui5/test/qlpack.yml
@@ -1,5 +1,5 @@
 name: advanced-security/javascript-sap-ui5-queries-tests
-version: 0.2.0
+version: 0.3.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^0.6.3"


### PR DESCRIPTION
Bump version of these for a new release:
- `advanced-security/javascript-sap-ui5-queries` to 0.3.0
- `advanced-security/javascript-sap-ui5-models` to 0.3.0