### PR TITLE
Broaden the requirements for an XML view

### DIFF
--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5View.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5View.qll
@@ -399,12 +399,44 @@ class XmlBindingPath extends UI5BindingPath instanceof XmlAttribute {
   }
 }
 
+class XmlRootElement extends XmlElement {
+  XmlRootElement() { any(XmlFile f).getARootElement() = this }
+
+  /**
+   * Returns a XML namespace declaration scoped to the element.
+   * 
+   * The predicate relies on location information to determine the scope of the namespace declaration.
+   * A XML element with the same starting line and column, but a larger ending line and column is considered the
+   * scope of the namespace declaration.
+   */
+  XmlNamespace getANamespaceDeclaration() {
+    exists(Location elemLoc, Location nsLoc |
+      elemLoc = this.getLocation() and
+      nsLoc = result.getLocation()
+     |
+     elemLoc.getStartLine() = nsLoc.getStartLine() and
+     elemLoc.getStartColumn() = nsLoc.getStartColumn() and
+      (
+        elemLoc.getEndLine() > nsLoc.getEndLine()
+        or
+        elemLoc.getEndLine() = nsLoc.getEndLine() and
+        elemLoc.getEndColumn() > nsLoc.getEndColumn()
+      )
+    )
+  }
+}
+
 class XmlView extends UI5View, XmlFile {
-  XmlElement root;
+  XmlRootElement root;
 
   XmlView() {
     root = this.getARootElement() and
-    root.getNamespace().getUri() = "sap.ui.core.mvc" and
+    (
+      root.getNamespace().getUri() = "sap.ui.core.mvc"
+      or
+      root.getNamespace().getUri() = "sap.ui.core" and
+      root.getANamespaceDeclaration().getUri() = "sap.ui.core.mvc"
+    ) and
     root.hasName("View")
   }
 
@@ -510,7 +542,7 @@ abstract class UI5Control extends Locatable {
   CustomController getController() { result = this.getView().getController() }
 }
 
-class XmlControl extends UI5Control, XmlElement {
+class XmlControl extends UI5Control instanceof XmlElement  {
   XmlControl() { this.getParent+() = any(XmlView view) }
 
   /** Get the qualified type string, e.g. `sap.m.SearchField` */
@@ -523,11 +555,11 @@ class XmlControl extends UI5Control, XmlElement {
     result = any(CustomControl control | control.getName() = this.getQualifiedType())
   }
 
-  override Location getLocation() { result = XmlElement.super.getLocation() }
+  override Location getLocation() { result = this.(XmlElement).getLocation() }
 
   override XmlFile getFile() { result = XmlElement.super.getFile() }
 
-  override UI5ControlProperty getAProperty(string name) { result = this.getAttribute(name) }
+  override UI5ControlProperty getAProperty(string name) { result = this.(XmlElement).getAttribute(name) }
 
   override CustomControl getDefinition() {
     result.getName() = this.getQualifiedType() and


### PR DESCRIPTION
We have discovered XML views that have the namespace `sap.ui.core` instead of the `sap.ui.core.mvc`.
To detect these XML views we now include root elements with:
- the name `View`, and
- a namespace `sap.ui.core.mvc`, or `sap.ui.core`, but with a namespace declaration for `sap.ui.core.mvc`.