### PR TITLE
Add heuristic model pack

### DIFF
--- a/javascript/heuristic-models/ext/additional-sources.model.yml
+++ b/javascript/heuristic-models/ext/additional-sources.model.yml
@@ -1,0 +1,16 @@
+extensions:
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: "typeModel"
+    data:
+      - ["XMLHttpRequest", "global", "Member[XMLHttpRequest].Instance"] 
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: "sourceModel"
+    data:
+      - ["XMLHttpRequest", "Member[responseText]", "remote"]
+      - ["XMLHttpRequest", "Member[responseXML]", "remote"]
+      - ["XMLHttpRequest", "Member[response]", "remote"]
+      - ["XMLHttpRequest", "Member[statusText]", "remote"]
+      - ["XMLHttpRequest", "Member[getResponseHeader]", "remote"]
+      - ["XMLHttpRequest", "Member[getResponseHeaders]", "remote"]

--- a/javascript/heuristic-models/ext/qlpack.yml
+++ b/javascript/heuristic-models/ext/qlpack.yml
@@ -1,0 +1,9 @@
+---
+library: true 
+warnOnImplicitThis: false
+name: advanced-security/javascript-heuristic-models
+version: 0.0.1
+extensionTargets:
+  codeql/javascript-all: "*"
+dataExtensions:
+  - "*.model.yml"

--- a/javascript/heuristic-models/tests/Sources/Sources.expected
+++ b/javascript/heuristic-models/tests/Sources/Sources.expected
@@ -1,0 +1,1 @@
+| test.js:5:17:5:32 | req.responseText |

--- a/javascript/heuristic-models/tests/Sources/Sources.ql
+++ b/javascript/heuristic-models/tests/Sources/Sources.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from RemoteFlowSource source
+select source

--- a/javascript/heuristic-models/tests/Sources/test.js
+++ b/javascript/heuristic-models/tests/Sources/test.js
@@ -1,0 +1,6 @@
+function test(url) {
+    const req = new XMLHttpRequest();
+    req.open(url);
+    req.send("foo");
+    console.log(req.responseText);
+}

--- a/javascript/heuristic-models/tests/codeql-pack.lock.yml
+++ b/javascript/heuristic-models/tests/codeql-pack.lock.yml
@@ -1,0 +1,16 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/javascript-all:
+    version: 0.8.4
+  codeql/mad:
+    version: 0.2.4
+  codeql/regex:
+    version: 0.2.4
+  codeql/tutorial:
+    version: 0.2.4
+  codeql/util:
+    version: 0.2.4
+  codeql/yaml:
+    version: 0.2.4
+compiled: false

--- a/javascript/heuristic-models/tests/qlpack.yml
+++ b/javascript/heuristic-models/tests/qlpack.yml
@@ -1,0 +1,8 @@
+library: false 
+warnOnImplicitThis: false
+name: advanced-security/javascript-heuristic-models-tests
+version: 0.0.1
+extractor: javascript
+dependencies:
+  "codeql/javascript-all": "*"
+  "advanced-security/javascript-heuristic-models": "*"


### PR DESCRIPTION
This pack will hold the heuristic models part of the standard library for easy enablement.
Currently, only holds source models for XMLHttpRequest.