### PR TITLE
Address CP between binding strings and static javascript binding

### DIFF
--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/BindingStringParser.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/BindingStringParser.qll
@@ -3,6 +3,12 @@ import javascript as stdlib
 signature class BindingStringReaderSig {
   string getBindingString();
   stdlib::Location getLocation();
+
+  // Get a dataflow node associated with the binding string, if any.
+  // Note that not all location from which we can obtain a binding string
+  // also have an associated data flow node. For example, as of writing
+  // XML attributes.
+  stdlib::DataFlow::Node getANode();
 }
 
 /**

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/Bindings.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/Bindings.qll
@@ -86,6 +86,22 @@ private class BindingStringReader extends TBindingString {
       result = bindProperty.getArgument(1).getALocalSource().asExpr().(StringLiteral).getLocation()
     )
   }
+
+  DataFlow::Node getANode() {
+    this = TBindingStringFromLiteral(result.asExpr())
+    or
+    exists(BindElementMethodCallNode bindElement |
+      this = TBindingStringFromBindElementMethodCall(bindElement) and
+      result = bindElement.getArgument(0).getALocalSource() and
+      result.asExpr() instanceof StringLiteral
+    )
+    or
+    exists(BindPropertyMethodCallNode bindProperty |
+      this = TBindingStringFromBindPropertyMethodCall(bindProperty) and
+      result = bindProperty.getArgument(1).getALocalSource() and
+      result.asExpr() instanceof StringLiteral
+    )
+  }
 }
 
 /**
@@ -203,7 +219,7 @@ private predicate earlyPropertyBinding(
   or
   // Composite binding https://ui5.sap.com/#/topic/a2fe8e763014477e87990ff50657a0d0
   exists(
-    DataFlow::ObjectLiteralNode objectLiteral, 
+    DataFlow::ObjectLiteralNode objectLiteral,
     DataFlow::ObjectLiteralNode valueLiteral, DataFlow::PropWrite partWrite,
     DataFlow::ArrayLiteralNode partsArray, DataFlow::ObjectLiteralNode partsElement,
     DataFlow::PropWrite pathWrite, DataFlow::ValueNode pathValue
@@ -387,7 +403,7 @@ private newtype TBindingPath =
           or
           binding = TLateJavaScriptContextBinding(_, possibleStaticBinding)
         ) and
-        possibleStaticBinding.mayHaveStringValue(parsedBinding.getReader().getBindingString())
+        possibleStaticBinding.getALocalSource() = parsedBinding.getReader().getANode()
       )
       or
       binding = TJsonPropertyBinding(_, _, parsedBinding)
@@ -480,7 +496,7 @@ class BindingPath extends TBindingPath {
   }
 
   Binding getBinding() {
-    this = TStaticBindingPath(result, _, _) 
+    this = TStaticBindingPath(result, _, _)
     or
     this = TDynamicBindingPath(result, _, _)
   }

--- a/javascript/frameworks/ui5/test/lib/BindingStringParser/BindingStringParser.ql
+++ b/javascript/frameworks/ui5/test/lib/BindingStringParser/BindingStringParser.ql
@@ -10,6 +10,10 @@ class BindingStringReader extends StringLiteral {
     string getBindingString() {
         result = this.getValue()
     }
+    
+    DataFlow::Node getANode() {
+        result.asExpr() = this
+    } 
 }
 
 module BindingStringParser = Make::BindingStringParser<BindingStringReader>;


### PR DESCRIPTION
This introduces a new required member predicate to the binding string reader signature that returns an data flow node representing the binding string if such a data flow node exists.

This allows us to limit the binding strings to those that flow to the property being bound when there are multiple binding strings that are equivalent.