### PR TITLE
Refine Code Scanning workflow configuration

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -8,8 +8,8 @@ queries:
   - uses: ./javascript/frameworks/cap/src
   
 query-filters:
-  - exclude:
-    problem.severity: recommendation
+  - include:
+    tags contain: security
 
 paths:
   - "**/*.xml"


### PR DESCRIPTION
- Exclude `models` folder from Code Scanning configuration
- Include queries with tag `security`