### PR TITLE
Bump version of `qlpack.yml`s for CAP release

### DIFF
--- a/javascript/frameworks/cap/ext/qlpack.yml
+++ b/javascript/frameworks/cap/ext/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-cap-models
-version: 0.2.0
+version: 0.3.0
 extensionTargets:
   codeql/javascript-all: "^1.1.1"
   codeql/javascript-queries: "^1.1.0"

--- a/javascript/frameworks/cap/lib/qlpack.yml
+++ b/javascript/frameworks/cap/lib/qlpack.yml
@@ -1,9 +1,9 @@
 ---
 library: true
 name: advanced-security/javascript-sap-cap-all
-version: 0.2.0
+version: 0.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^1.1.1"
-  advanced-security/javascript-sap-cap-models: "^0.2.0"
+  advanced-security/javascript-sap-cap-models: "^0.3.0"

--- a/javascript/frameworks/cap/src/qlpack.yml
+++ b/javascript/frameworks/cap/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-cap-queries
-version: 0.2.0
+version: 0.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^1.1.1"
-  advanced-security/javascript-sap-cap-models: "^0.2.0"
-  advanced-security/javascript-sap-cap-all: "^0.2.0"
+  advanced-security/javascript-sap-cap-models: "^0.3.0"
+  advanced-security/javascript-sap-cap-all: "^0.3.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/cap/test/qlpack.yml
+++ b/javascript/frameworks/cap/test/qlpack.yml
@@ -1,10 +1,10 @@
 ---
 name: advanced-security/javascript-sap-cap-queries-tests
-version: 0.2.0
+version: 0.3.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^1.1.1"
   codeql/javascript-queries: "^1.1.0"
-  advanced-security/javascript-sap-cap-queries: "^0.2.0"
-  advanced-security/javascript-sap-cap-models: "^0.2.0"
-  advanced-security/javascript-sap-cap-all: "^0.2.0"
+  advanced-security/javascript-sap-cap-queries: "^0.3.0"
+  advanced-security/javascript-sap-cap-models: "^0.3.0"
+  advanced-security/javascript-sap-cap-all: "^0.3.0"


### PR DESCRIPTION
Bump version of `qlpack.yml`s at 
- javascript/frameworks/cap/ext
- javascript/frameworks/cap/lib
- javascript/frameworks/cap/src
- and javascript/frameworks/cap/test 
for release.