### PR TITLE
CDL: Improve performance by simplifying CDS location identification

### DIFF
--- a/.github/workflows/run-codeql-unit-tests-javascript.yml
+++ b/.github/workflows/run-codeql-unit-tests-javascript.yml
@@ -87,13 +87,20 @@ jobs:
       # Compile .cds files to .cds.json files.
       - name: Compile CAP CDS files
         run: |
-          for cds_file in $(find . -type f \( -iname '*.cds' \) -print)
+          for test_dir in $(find . -type f -name '*.expected' -exec dirname {} \;);
           do
-            echo "I am compiling $cds_file"
-            cds compile $cds_file \
-              -2 json \
-              -o "$cds_file.json" \
-              --locations
+            # The CDS compiler produces locations relative to the working directory
+            # so we switch to the test directory before running the compiler.
+            pushd $test_dir
+            for cds_file in $(find . -type f \( -iname '*.cds' \) -print)
+            do
+              echo "I am compiling $cds_file"
+              cds compile $cds_file \
+                -2 json \
+                -o "$cds_file.json" \
+                --locations
+            done
+            popd
           done
 
       - name: Run test suites
@@ -105,7 +112,7 @@ jobs:
           CODEQL_STDLIB_IDENT: ${{matrix.codeql_standard_library_ident}}
           RUNNER_TMP: ${{ runner.temp }}
           LGTM_INDEX_XML_MODE: all
-          LGTM_INDEX_FILETYPES: ".json:JSON"
+          LGTM_INDEX_FILETYPES: ".json:JSON\n.cds:JSON"
 
         shell: bash
         run: >

--- a/javascript/frameworks/cap/lib/advanced_security/javascript/frameworks/cap/CDL.qll
+++ b/javascript/frameworks/cap/lib/advanced_security/javascript/frameworks/cap/CDL.qll
@@ -16,10 +16,14 @@ abstract class CdlObject extends JsonObject {
         locValue = this.getPropValue("$location") and
         // The path in the cds.json file is relative to the working directory used when running
         // the cds compile command. In our extractor, that's always the root of the repository,
-        // so we can identify the entry in the `File` table by its relative path.
-        path =
-          any(File f | f.getRelativePath() = locValue.getPropValue("file").getStringValue())
-              .getAbsolutePath() and
+        // so we can identify the sourceLocationPrefix to find the path of the root of the repo
+        // then append the relative path
+        exists(string sourceLocationPrefix |
+          sourceLocationPrefix(sourceLocationPrefix) and
+          path =
+            sourceLocationPrefix.regexpReplaceAll("/$", "") + "/" +
+              locValue.getPropValue("file").getStringValue()
+        ) and
         if
           not exists(locValue.getPropValue("line")) and
           not exists(locValue.getPropValue("col"))

--- a/javascript/frameworks/cap/lib/advanced_security/javascript/frameworks/cap/CDL.qll
+++ b/javascript/frameworks/cap/lib/advanced_security/javascript/frameworks/cap/CDL.qll
@@ -14,11 +14,12 @@ abstract class CdlObject extends JsonObject {
       exists(Location loc, JsonValue locValue |
         loc = this.getLocation() and
         locValue = this.getPropValue("$location") and
+        // The path in the cds.json file is relative to the working directory used when running
+        // the cds compile command. In our extractor, that's always the root of the repository,
+        // so we can identify the entry in the `File` table by its relative path.
         path =
-          any(File f |
-            f.getAbsolutePath()
-                .matches("%" + locValue.getPropValue("file").getStringValue() + ".json")
-          ).getAbsolutePath().regexpReplaceAll("\\.json$", "") and
+          any(File f | f.getRelativePath() = locValue.getPropValue("file").getStringValue())
+              .getAbsolutePath() and
         if
           not exists(locValue.getPropValue("line")) and
           not exists(locValue.getPropValue("col"))

--- a/qlt.conf.json
+++ b/qlt.conf.json
@@ -1,5 +1,5 @@
 {
-  "CodeQLCLI": "2.19.0",
-  "CodeQLStandardLibrary": "codeql-cli/v2.19.0",
-  "CodeQLCLIBundle": "codeql-bundle-v2.19.0"
+  "CodeQLCLI": "2.19.4",
+  "CodeQLStandardLibrary": "codeql-cli/v2.19.4",
+  "CodeQLCLIBundle": "codeql-bundle-v2.19.4"
 }


### PR DESCRIPTION
We can assume that the path in the cds.json is relative to the repository root, as that is the directory the CDS compiler is run from.