### PR TITLE
Run `cds compile` command without `-o` option

### DIFF
--- a/.github/workflows/run-codeql-unit-tests-javascript.yml
+++ b/.github/workflows/run-codeql-unit-tests-javascript.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           if ! command -v cds &> /dev/null
           then
+            ## Workaround for https://github.tools.sap/cap/issues/issues/17840
             npm install -g @sap/cds-dk@8.6.1
           fi
 
@@ -97,8 +98,8 @@ jobs:
               echo "I am compiling $cds_file"
               cds compile $cds_file \
                 -2 json \
-                -o "$cds_file.json" \
-                --locations
+                --locations \
+                > "$cds_file.json" 2> "$cds_file.err"
             done
             popd
           done

--- a/extractors/cds/tools/index-files.sh
+++ b/extractors/cds/tools/index-files.sh
@@ -52,7 +52,7 @@ echo "Processing CDS files to JSON"
 # the same name
 while IFS= read -r cds_file; do
     echo "Processing CDS file $cds_file to:"
-    if ! $cds_command compile "$cds_file" -2 json -o "$cds_file.json" --locations 2> "$cds_file.err"; then
+    if ! $cds_command compile "$cds_file" -2 json --locations > "$cds_file.json" 2> "$cds_file.err"; then
         stderr_truncated=`grep "^\[ERROR\]" "$cds_file.err" | tail -n 4`
         error_message=$'Could not compile the file '"$cds_file"$'.\nReported error(s):\n```\n'"$stderr_truncated"$'\n```'
         echo "$error_message"


### PR DESCRIPTION
Updates unit-test and cds-extractor use of the `cds compile` command in order to avoid the use of the `-o` option, which outputs to a directory instead of a file, as intended. Replaces use of the `-o` option with a simple redirect of cds compiler output to stdout, which is redirected to the indended '.cds.json' file path.

This commit should resolve failures for both code scanning and unit test workflows for this project/repo.