### PR TITLE
Rename pack `javascript-sap-xsjs-lib` to `javascript-sap-xsjs-all`

### DIFF
--- a/javascript/frameworks/xsjs/lib/qlpack.yml
+++ b/javascript/frameworks/xsjs/lib/qlpack.yml
@@ -1,6 +1,6 @@
 ---
 library: true
-name: advanced-security/javascript-sap-xsjs-lib
+name: advanced-security/javascript-sap-xsjs-all
 version: 0.2.0
 suites: codeql-suites
 extractor: javascript

--- a/javascript/frameworks/xsjs/src/qlpack.yml
+++ b/javascript/frameworks/xsjs/src/qlpack.yml
@@ -7,5 +7,5 @@ extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
   advanced-security/javascript-sap-xsjs-models: "^0.2.0"
-  advanced-security/javascript-sap-xsjs-lib: "^0.2.0"
+  advanced-security/javascript-sap-xsjs-all: "^0.2.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/xsjs/test/qlpack.yml
+++ b/javascript/frameworks/xsjs/test/qlpack.yml
@@ -5,4 +5,4 @@ extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
   advanced-security/javascript-sap-xsjs-queries: "^0.2.0"
-  advanced-security/javascript-sap-xsjs-lib: "^0.2.0"
+  advanced-security/javascript-sap-xsjs-all: "^0.2.0"


### PR DESCRIPTION
This PR renames the qlpack declared at `javascript/frameworks/xsjs/lib/` from `advanced-security/javascript-sap-xsjs-lib` to `advanced-security/javascript-sap-xsjs-all`.

The qlpacks are named with the following schema:
- `ext/` => `javascript-sap-{framework}-models`
- `lib/` => `javascript-sap-{framework}-all`
- `src/` => `javascript-sap-{framework}-queries`
- `test/` => `javascript-sap-{framework}-test` (though these are not published.)

However, the XSJS library pack did not have `javascript-sap-xsjs-all` but `javascript-sap-xsjs-lib` as its name. Therefore, normalize the qlpack name to conform to the naming schema.