### PR TITLE
Add `Customizations.qll` files to support integration of sources into Custom CodeQL bundles

### DIFF
--- a/javascript/frameworks/cap/lib/advanced_security/javascript_sap_cap_all/Customizations.qll
+++ b/javascript/frameworks/cap/lib/advanced_security/javascript_sap_cap_all/Customizations.qll
@@ -1,0 +1,6 @@
+// This file is included for use in custom CodeQL bundles (https://github.com/advanced-security/codeql-bundle).
+// The contents of this file will be included in the standard library `Customizations.qll`, and will therefore
+// be included in the out-of-the-box security queries.
+//
+// We import under alias to avoid any potential naming conflicts
+import advanced_security.javascript.frameworks.cap.RemoteFlowSources as CAPRemoteFlowSources

--- a/javascript/frameworks/cap/lib/qlpack.yml
+++ b/javascript/frameworks/cap/lib/qlpack.yml
@@ -6,4 +6,3 @@ suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-cap-models: "^0.4.0"

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript_sap_ui5_all/Customizations.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript_sap_ui5_all/Customizations.qll
@@ -1,0 +1,6 @@
+// This file is included for use in custom CodeQL bundles (https://github.com/advanced-security/codeql-bundle).
+// The contents of this file will be included in the standard library `Customizations.qll`, and will therefore
+// be included in the out-of-the-box security queries.
+//
+// We import under alias to avoid any potential naming conflicts
+import advanced_security.javascript.frameworks.ui5.RemoteFlowSources as UI5RemoteFlowSources

--- a/javascript/frameworks/ui5/lib/qlpack.yml
+++ b/javascript/frameworks/ui5/lib/qlpack.yml
@@ -6,4 +6,3 @@ suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-ui5-models: "^0.7.0"


### PR DESCRIPTION
Add `Customizations.qll` files to the CAP and UI5 library packs. These files enable the packs to be added to a CodeQL CLI custom bundle as a "customization" pack, which enables us to add custom `RemoteFlowSources` to out-of-the-box queries.