### PR TITLE
Add support for indexing UI5 XML views

### DIFF
--- a/extractors/javascript/tools/pre-finalize.sh
+++ b/extractors/javascript/tools/pre-finalize.sh
@@ -15,3 +15,19 @@ if [ -z "${CODEQL_EXTRACTOR_CDS_SKIP_EXTRACTION:-}" ]; then
         -- \
         "$CODEQL_EXTRACTOR_JAVASCRIPT_WIP_DATABASE"
 fi
+
+# Index UI5 *.view.xml files
+"${CODEQL_DIST}/codeql" database index-files \
+    --include-extension=.view.xml \
+    --language xml \
+    --prune **/node_modules/**/* \
+    --prune **/.eslint/**/* \
+    --total-size-limit=10m \
+    -- \
+    "$CODEQL_EXTRACTOR_JAVASCRIPT_WIP_DATABASE"
+
+# UI5 also requires *.view.json files and *.view.html files be indexed, but these are indexed by
+# default by CodeQL.
+
+# XSJS also requires indexing of *.xsaccess files, *.xsjs files and xs-app.json files, but these
+# are indexed by default by CodeQL.


### PR DESCRIPTION
This PR adds support to our JavaScript extractor hook to automatically index UI5 XML views.

Per the [documentation](https://sapui5.hana.ondemand.com/sdk/#/topic/91f292806f4d1014b6dd926db0e91070.html) all such views should end with the suffix `.view.xml`, so we do not need to consider the contents when determining what to index.

In addition to this PR, I have also [opened a PR on `github/codeql`](https://github.com/github/codeql/pull/19117) to ensure the following relevant UI5 and XSJS `.json` files are indexed:
 * `*.view.json`
 * `xs-app.json`
 * `manifest.json`

We document this in the `post-finalize.sh` hook to ensure it's clear where this happens.

@jeongsoolee09 can you please confirm that after these changes we would now capture all relevant CAP, UI5 and XSJS files during extraction?