### PR TITLE
Improve logging and quoting in extractor scripts

### DIFF
--- a/extractors/cds/tools/autobuild.sh
+++ b/extractors/cds/tools/autobuild.sh
@@ -3,10 +3,10 @@
 set -eu
 
 exec "${CODEQL_DIST}/codeql" database index-files \
-    --include-extension=.cds \
-    --language cds \
-    --prune **/node_modules/**/* \
-    --prune **/.eslint/**/* \
-    --total-size-limit=10m \
+    --include-extension=".cds" \
+    --language="cds" \
+    --prune="**/node_modules/**/*" \
+    --prune="**/.eslint/**/*" \
+    --total-size-limit="10m" \
     -- \
     "$CODEQL_EXTRACTOR_CDS_WIP_DATABASE"

--- a/extractors/cds/tools/index-files.js
+++ b/extractors/cds/tools/index-files.js
@@ -365,3 +365,5 @@ spawnSync(
     [],
     { cwd: sourceRoot, env: process.env, shell: true, stdio: 'inherit' }
 );
+
+console.log(`Completed run of index-files.js script for CDS extractor.`);

--- a/extractors/javascript/tools/pre-finalize.sh
+++ b/extractors/javascript/tools/pre-finalize.sh
@@ -5,26 +5,34 @@ set -eu
 # Do not extract CDS files if the CODEQL_EXTRACTOR_CDS_SKIP_EXTRACTION
 # environment variable is set.
 if [ -z "${CODEQL_EXTRACTOR_CDS_SKIP_EXTRACTION:-}" ]; then
-    # Call the index-files command with the CDS extractor
+    echo "Running database index-files for CDS (.cds) files ..."
+
+    # Call the index-files command with the CDS extractor.
     "${CODEQL_DIST}/codeql" database index-files \
-        --include-extension=.cds \
-        --language cds \
-        --prune **/node_modules/**/* \
-        --prune **/.eslint/**/* \
-        --total-size-limit=10m \
+        --include-extension=".cds" \
+        --language="cds" \
+        --prune="**/node_modules/**/*" \
+        --prune="**/.eslint/**/*" \
+        --total-size-limit="10m" \
         -- \
         "$CODEQL_EXTRACTOR_JAVASCRIPT_WIP_DATABASE"
+
+    echo "Finished running database index-files for CDS (.cds) files."
 fi
 
-# Index UI5 *.view.xml files
+echo "Running database index-files for UI5 (.view.xml) files ..."
+
+# Index UI5 *.view.xml files.
 "${CODEQL_DIST}/codeql" database index-files \
-    --include-extension=.view.xml \
-    --language xml \
-    --prune **/node_modules/**/* \
-    --prune **/.eslint/**/* \
-    --total-size-limit=10m \
+    --include-extension=".view.xml" \
+    --language="xml" \
+    --prune="**/node_modules/**/*" \
+    --prune="**/.eslint/**/*" \
+    --total-size-limit="10m" \
     -- \
     "$CODEQL_EXTRACTOR_JAVASCRIPT_WIP_DATABASE"
+
+echo "Finished running database index-files for UI5 (.view.xml) files."
 
 # UI5 also requires *.view.json files and *.view.html files be indexed, but these are indexed by
 # default by CodeQL.


### PR DESCRIPTION
Adds minimal logging statements to make it easier to debug which extractor script is running and/or producing an error.

Adds double-quotes to string parameters used in extractor (bash) scripts in order to (hopefully) avoid problems related to shell escaping of glob patterns.