### PR TITLE
Prepend the receiver `process` to `exit(0)`

### DIFF
--- a/extractors/cds/tools/index-files.js
+++ b/extractors/cds/tools/index-files.js
@@ -157,7 +157,7 @@ try {
     // compiler dependencies may be installed.
     if (packageJsonDirs.size === 0) {
         console.warn('WARN: failed to detect any package.json directories for cds compiler installation.');
-        exit(0);
+        process.exit(0);
     }
 
     packageJsonDirs.forEach((dir) => {


### PR DESCRIPTION
Explicitly state the reference to global variable `process` before the call to `exit`.