### PR TITLE
Fix: replace `exit(0)` with `process.exit(0)` for process termination

### DIFF
--- a/extractors/cds/tools/index-files.js
+++ b/extractors/cds/tools/index-files.js
@@ -157,7 +157,7 @@ try {
     // compiler dependencies may be installed.
     if (packageJsonDirs.size === 0) {
         console.warn('WARN: failed to detect any package.json directories for cds compiler installation.');
-        exit(0);
+        process.exit(0);
     }
 
     packageJsonDirs.forEach((dir) => {


### PR DESCRIPTION
The script uses `exit(0)` to terminate execution, but exit is not defined, causing a runtime error. This should be replaced with `process.exit(0)` for proper functionality.