### PR TITLE
Bump all QL pack versions to 2.0.0

### DIFF
--- a/javascript/frameworks/cap/ext/qlpack.yml
+++ b/javascript/frameworks/cap/ext/qlpack.yml
@@ -1,6 +1,6 @@
 ---
 library: true
 name: advanced-security/javascript-sap-cap-models
-version: 0.4.0
+version: 2.0.0
 extensionTargets:
   codeql/javascript-all: "^2.4.0"

--- a/javascript/frameworks/cap/lib/qlpack.yml
+++ b/javascript/frameworks/cap/lib/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-cap-all
-version: 0.4.0
+version: 2.0.0
 suites: codeql-suites
 extractor: javascript
 dependencies:

--- a/javascript/frameworks/cap/src/qlpack.yml
+++ b/javascript/frameworks/cap/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-cap-queries
-version: 0.4.0
+version: 2.0.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-cap-models: "^0.4.0"
-  advanced-security/javascript-sap-cap-all: "^0.4.0"
+  advanced-security/javascript-sap-cap-models: "^2.0.0"
+  advanced-security/javascript-sap-cap-all: "^2.0.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/cap/test/qlpack.yml
+++ b/javascript/frameworks/cap/test/qlpack.yml
@@ -1,9 +1,9 @@
 ---
 name: advanced-security/javascript-sap-cap-queries-tests
-version: 0.4.0
+version: 2.0.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-cap-queries: "^0.4.0"
-  advanced-security/javascript-sap-cap-models: "^0.4.0"
-  advanced-security/javascript-sap-cap-all: "^0.4.0"
+  advanced-security/javascript-sap-cap-queries: "^2.0.0"
+  advanced-security/javascript-sap-cap-models: "^2.0.0"
+  advanced-security/javascript-sap-cap-all: "^2.0.0"

--- a/javascript/frameworks/ui5/ext/qlpack.yml
+++ b/javascript/frameworks/ui5/ext/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-ui5-models
-version: 0.7.0
+version: 2.0.0
 extensionTargets:
   codeql/javascript-all: "^2.4.0"
 dataExtensions:

--- a/javascript/frameworks/ui5/lib/qlpack.yml
+++ b/javascript/frameworks/ui5/lib/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-ui5-all
-version: 0.7.0
+version: 2.0.0
 suites: codeql-suites
 extractor: javascript
 dependencies:

--- a/javascript/frameworks/ui5/src/qlpack.yml
+++ b/javascript/frameworks/ui5/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-ui5-queries
-version: 0.7.0
+version: 2.0.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-ui5-models: "^0.7.0"
-  advanced-security/javascript-sap-ui5-all: "^0.7.0"
+  advanced-security/javascript-sap-ui5-models: "^2.0.0"
+  advanced-security/javascript-sap-ui5-all: "^2.0.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/ui5/test/qlpack.yml
+++ b/javascript/frameworks/ui5/test/qlpack.yml
@@ -1,5 +1,5 @@
 name: advanced-security/javascript-sap-ui5-queries-tests
-version: 0.7.0
+version: 2.0.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
@@ -7,6 +7,6 @@ dependencies:
   # no overlap occurs with the SAP UI5 queries. We therefore allow any version
   # greater than or equal to 1.2.0, as major breaking changes are not a concern.
   codeql/javascript-queries: ">1.2.0"
-  advanced-security/javascript-sap-ui5-queries: "^0.7.0"
-  advanced-security/javascript-sap-ui5-models: "^0.7.0"
-  advanced-security/javascript-sap-ui5-all: "^0.7.0"
+  advanced-security/javascript-sap-ui5-queries: "^2.0.0"
+  advanced-security/javascript-sap-ui5-models: "^2.0.0"
+  advanced-security/javascript-sap-ui5-all: "^2.0.0"

--- a/javascript/frameworks/xsjs/ext/qlpack.yml
+++ b/javascript/frameworks/xsjs/ext/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-xsjs-models
-version: 0.2.0
+version: 2.0.0
 extensionTargets:
   codeql/javascript-all: "^2.4.0"
 dataExtensions:

--- a/javascript/frameworks/xsjs/lib/qlpack.yml
+++ b/javascript/frameworks/xsjs/lib/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-xsjs-all
-version: 0.2.0
+version: 2.0.0
 suites: codeql-suites
 extractor: javascript
 dependencies:

--- a/javascript/frameworks/xsjs/src/qlpack.yml
+++ b/javascript/frameworks/xsjs/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-xsjs-queries
-version: 0.2.0
+version: 2.0.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-xsjs-models: "^0.2.0"
-  advanced-security/javascript-sap-xsjs-all: "^0.2.0"
+  advanced-security/javascript-sap-xsjs-models: "^2.0.0"
+  advanced-security/javascript-sap-xsjs-all: "^2.0.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/xsjs/test/qlpack.yml
+++ b/javascript/frameworks/xsjs/test/qlpack.yml
@@ -1,8 +1,8 @@
 ---
 name: advanced-security/javascript-sap-xsjs-tests
-version: 0.2.0
+version: 2.0.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-xsjs-queries: "^0.2.0"
-  advanced-security/javascript-sap-xsjs-all: "^0.2.0"
+  advanced-security/javascript-sap-xsjs-queries: "^2.0.0"
+  advanced-security/javascript-sap-xsjs-all: "^2.0.0"

--- a/javascript/heuristic-models/ext/qlpack.yml
+++ b/javascript/heuristic-models/ext/qlpack.yml
@@ -2,7 +2,7 @@
 library: true
 warnOnImplicitThis: false
 name: advanced-security/javascript-heuristic-models
-version: 0.0.1
+version: 2.0.0
 extensionTargets:
   codeql/javascript-all: "*"
 dataExtensions:

--- a/javascript/heuristic-models/tests/qlpack.yml
+++ b/javascript/heuristic-models/tests/qlpack.yml
@@ -5,4 +5,4 @@ version: 0.0.1
 extractor: javascript
 dependencies:
   "codeql/javascript-all": "*"
-  "advanced-security/javascript-heuristic-models": "*"
+  "advanced-security/javascript-heuristic-models": 2.0.0


### PR DESCRIPTION
## What This PR Contributes

Unify all `version` of `qlpack.yml` to `2.0.0`. This version number is the tag for the next release.

So far, the versions were all different across qlpacks for each framework and the `heuristic-models` pack. However, as we plan to do a release, the differences make version numbers fragmented and would make the version lookup a bit tedious (e.g. "which qlpack version correlates to which release tag?"). Therefore, make the versions match the tag versions while bumping it to the next major version in terms of the release tag.

## Future Works

- Make a release with version `v2.0.0`.
- Automate some of the release process:
  1. Automatically bump the version numbers.
  2. Check every night if there is a new CLI release and if so, create a new PR with updated version number in `qlt.conf.json`.