### PR TITLE
Automatically open PR to upgrade CodeQL CLI dependencies

### DIFF
--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -24,7 +24,7 @@ jobs:
           run: |
             echo "Checking latest CodeQL CLI version"
             current_version=$(jq .CodeQLCLI qlt.conf.json -r)
-            latest_version=$(curl -s https://api.github.com/repos/github/codeql-cli-binaries/releases/latest | jq -r .tag_name)
+            latest_version=$(gh release list --repo github/codeql-cli-binaries --json 'tagName,isLatest' --jq '.[] | select(.isLatest == true) | .tagName')
             echo "Current CodeQL CLI version: $current_version"
             echo "Latest CodeQL CLI version: $latest_version"
 

--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -71,6 +71,26 @@ jobs:
             echo "CodeQL Home: $QLT_CODEQL_HOME"
             echo "CodeQL Binary: $QLT_CODEQL_PATH"
 
+        - name: Upgrade CodeQL pack lock files
+          if: steps.check-version.outputs.update_needed == 'true'
+          shell: bash
+          run: |
+            echo "Upgrading CodeQL pack lock files"
+            echo "Finding all directories with qlpack.yml files..."
+            
+            # Find all directories containing qlpack.yml files
+            find . -name "qlpack.yml" -type f | while read -r qlpack_file; do
+              pack_dir=$(dirname "$qlpack_file")
+              echo "Upgrading pack in directory: $pack_dir"
+              
+              # Change to the directory and run codeql pack upgrade
+              cd "$pack_dir"
+              codeql pack upgrade
+              cd - > /dev/null
+            done
+            
+            echo "Finished upgrading all CodeQL pack lock files"
+
         - name: Create Pull Request
           if: steps.check-version.outputs.update_needed == 'true'
           uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
@@ -83,6 +103,7 @@ jobs:
                 - Updated `CodeQLCLI` to `${{ steps.check-version.outputs.latest_version }}`
                 - Updated `CodeQLStandardLibrary` to `codeql-cli/${{ steps.check-version.outputs.latest_version_tag }}`
                 - Updated `CodeQLCLIBundle` to `codeql-bundle-${{ steps.check-version.outputs.latest_version_tag }}`
+                - Upgraded all CodeQL pack lock files using `codeql pack upgrade`
             commit-message: "Upgrade CodeQL CLI dependency to ${{ steps.check-version.outputs.latest_version_tag }}"
             delete-branch: true
             branch: "codeql/upgrade-to-${{ steps.check-version.outputs.latest_version_tag }}"

--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -1,0 +1,84 @@
+name: "Update the CodeQL CLI dependencies"
+
+on:
+    workflow_dispatch:
+    # nightly runs to update the CodeQL CLI dependencies
+    schedule:
+      - cron: '30 0 * * *'
+
+jobs:
+    update-codeql:
+        name: Update CodeQL CLI dependencies
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Check latest CodeQL CLI version and update qlt.conf.json
+          id: check-version
+          run: |
+            echo "Checking latest CodeQL CLI version"
+            current_version=$(jq .CodeQLCLI qlt.conf.json -r)
+            latest_version=$(curl -s https://api.github.com/repos/github/codeql-cli-binaries/releases/latest | jq -r .tag_name)
+            echo "Current CodeQL CLI version: $current_version"
+            echo "Latest CodeQL CLI version: $latest_version"
+            
+            # Remove 'v' prefix if present for comparison with current version
+            latest_clean=$(echo "$latest_version" | sed 's/^v//')
+            
+            if [ "$latest_clean" != "$current_version" ]; then
+              echo "Updating CodeQL CLI from $current_version to $latest_clean"
+              echo "update_needed=true" >> $GITHUB_OUTPUT
+              echo "latest_version=$latest_clean" >> $GITHUB_OUTPUT
+              echo "latest_version_tag=$latest_version" >> $GITHUB_OUTPUT
+              
+              # Update qlt.conf.json with all properties
+              echo "Updating qlt.conf.json with all properties for version $latest_clean"
+              jq --arg cli_version "$latest_clean" \
+                 --arg std_lib "codeql-cli/$latest_version" \
+                 --arg bundle "codeql-bundle-$latest_version" \
+                 '.CodeQLCLI = $cli_version | .CodeQLStandardLibrary = $std_lib | .CodeQLCLIBundle = $bundle' \
+                 qlt.conf.json > qlt.conf.json.tmp && mv qlt.conf.json.tmp qlt.conf.json
+              
+              echo "Updated qlt.conf.json contents:"
+              cat qlt.conf.json
+            else
+              echo "CodeQL CLI is already up-to-date at version $current_version."
+              echo "update_needed=false" >> $GITHUB_OUTPUT
+            fi
+
+        - name: Install QLT
+          if: steps.check-version.outputs.update_needed == 'true'
+          id: install-qlt
+          uses: advanced-security/codeql-development-toolkit/.github/actions/install-qlt@main
+          with:
+            qlt-version: 'latest'
+            add-to-path: true
+
+        - name: Install CodeQL
+          if: steps.check-version.outputs.update_needed == 'true'
+          id: install-codeql
+          shell: bash
+          run: |
+            echo "Installing CodeQL"
+            qlt codeql run install
+            echo "-----------------------------"
+            echo "CodeQL Home: $QLT_CODEQL_HOME"
+            echo "CodeQL Binary: $QLT_CODEQL_PATH"
+
+        - name: Create Pull Request
+          if: steps.check-version.outputs.update_needed == 'true'
+          uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+          with:
+            title: "Upgrade CodeQL CLI dependency to ${{ steps.check-version.outputs.latest_version_tag }}"
+            body: |
+                This PR upgrades the CodeQL CLI version to ${{ steps.check-version.outputs.latest_version_tag }}.
+                
+                **Changes made:**
+                - Updated `CodeQLCLI` to `${{ steps.check-version.outputs.latest_version }}`
+                - Updated `CodeQLStandardLibrary` to `codeql-cli/${{ steps.check-version.outputs.latest_version_tag }}`
+                - Updated `CodeQLCLIBundle` to `codeql-bundle-${{ steps.check-version.outputs.latest_version_tag }}`
+            commit-message: "Upgrade CodeQL CLI dependency to ${{ steps.check-version.outputs.latest_version_tag }}"
+            delete-branch: true
+            branch: "codeql/upgrade-to-${{ steps.check-version.outputs.latest_version_tag }}"

--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -70,9 +70,6 @@ jobs:
             echo "-----------------------------"
             echo "CodeQL Home: $QLT_CODEQL_HOME"
             echo "CodeQL Binary: $QLT_CODEQL_PATH"
-            # Add CodeQL to the PATH
-            echo "Adding CodeQL to PATH"
-            echo "$QLT_CODEQL_PATH" >> $GITHUB_PATH
 
         - name: Upgrade CodeQL pack lock files
           if: steps.check-version.outputs.update_needed == 'true'
@@ -88,7 +85,7 @@ jobs:
 
               # Change to the directory and run codeql pack upgrade
               cd "$pack_dir"
-              codeql pack upgrade
+              $QLT_CODEQL_PATH pack upgrade
               cd - > /dev/null
             done
 

--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -6,6 +6,10 @@ on:
     schedule:
       - cron: '30 0 * * *'
 
+permissions:
+    contents: write
+    pull-requests: write
+
 jobs:
     update-codeql:
         name: Update CodeQL CLI dependencies

--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -27,16 +27,16 @@ jobs:
             latest_version=$(curl -s https://api.github.com/repos/github/codeql-cli-binaries/releases/latest | jq -r .tag_name)
             echo "Current CodeQL CLI version: $current_version"
             echo "Latest CodeQL CLI version: $latest_version"
-            
+
             # Remove 'v' prefix if present for comparison with current version
             latest_clean=$(echo "$latest_version" | sed 's/^v//')
-            
+
             if [ "$latest_clean" != "$current_version" ]; then
               echo "Updating CodeQL CLI from $current_version to $latest_clean"
               echo "update_needed=true" >> $GITHUB_OUTPUT
               echo "latest_version=$latest_clean" >> $GITHUB_OUTPUT
               echo "latest_version_tag=$latest_version" >> $GITHUB_OUTPUT
-              
+
               # Update qlt.conf.json with all properties
               echo "Updating qlt.conf.json with all properties for version $latest_clean"
               jq --arg cli_version "$latest_clean" \
@@ -44,7 +44,7 @@ jobs:
                  --arg bundle "codeql-bundle-$latest_version" \
                  '.CodeQLCLI = $cli_version | .CodeQLStandardLibrary = $std_lib | .CodeQLCLIBundle = $bundle' \
                  qlt.conf.json > qlt.conf.json.tmp && mv qlt.conf.json.tmp qlt.conf.json
-              
+
               echo "Updated qlt.conf.json contents:"
               cat qlt.conf.json
             else
@@ -77,18 +77,18 @@ jobs:
           run: |
             echo "Upgrading CodeQL pack lock files"
             echo "Finding all directories with qlpack.yml files..."
-            
+
             # Find all directories containing qlpack.yml files
             find . -name "qlpack.yml" -type f | while read -r qlpack_file; do
               pack_dir=$(dirname "$qlpack_file")
               echo "Upgrading pack in directory: $pack_dir"
-              
+
               # Change to the directory and run codeql pack upgrade
               cd "$pack_dir"
               codeql pack upgrade
               cd - > /dev/null
             done
-            
+
             echo "Finished upgrading all CodeQL pack lock files"
 
         - name: Create Pull Request
@@ -98,7 +98,7 @@ jobs:
             title: "Upgrade CodeQL CLI dependency to ${{ steps.check-version.outputs.latest_version_tag }}"
             body: |
                 This PR upgrades the CodeQL CLI version to ${{ steps.check-version.outputs.latest_version_tag }}.
-                
+
                 **Changes made:**
                 - Updated `CodeQLCLI` to `${{ steps.check-version.outputs.latest_version }}`
                 - Updated `CodeQLStandardLibrary` to `codeql-cli/${{ steps.check-version.outputs.latest_version_tag }}`

--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -70,6 +70,9 @@ jobs:
             echo "-----------------------------"
             echo "CodeQL Home: $QLT_CODEQL_HOME"
             echo "CodeQL Binary: $QLT_CODEQL_PATH"
+            # Add CodeQL to the PATH
+            echo "Adding CodeQL to PATH"
+            echo "$QLT_CODEQL_PATH" >> $GITHUB_PATH
 
         - name: Upgrade CodeQL pack lock files
           if: steps.check-version.outputs.update_needed == 'true'


### PR DESCRIPTION
## What This PR Contributes

This PR adds an Actions workflow which checks for new CodeQL CLI releases, and if one exists, opens a new PR to update the QLT config and the qlpack lock files. The workflow runs nightly on a schedule, and can also be run on demand.

Once this is merged, we should automatically get PRs opened after new CodeQL CLI releases, where the PR checks help validate compatibility with the repository.

## Future Works

This functionality could be incorporated directly into QLT in the future.
