### PR TITLE
Update CodeQL CLI upgrade workflow to include GH_TOKEN

### DIFF
--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -21,6 +21,8 @@ jobs:
 
         - name: Check latest CodeQL CLI version and update qlt.conf.json
           id: check-version
+          env:
+            GH_TOKEN: ${{ github.token }}
           run: |
             echo "Checking latest CodeQL CLI version"
             current_version=$(jq .CodeQLCLI qlt.conf.json -r)


### PR DESCRIPTION
## What This PR Contributes

We need to explicitly set the `GH_TOKEN` env var for the `gh` cli to work.

## Future Works

None.
