### PR TITLE
Bump qlpacks to 2.3.0

### DIFF
--- a/javascript/frameworks/cap/ext/qlpack.yml
+++ b/javascript/frameworks/cap/ext/qlpack.yml
@@ -1,6 +1,6 @@
 ---
 library: true
 name: advanced-security/javascript-sap-cap-models
-version: 2.2.0
+version: 2.3.0
 extensionTargets:
   codeql/javascript-all: "^2.4.0"

--- a/javascript/frameworks/cap/lib/qlpack.yml
+++ b/javascript/frameworks/cap/lib/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-cap-all
-version: 2.2.0
+version: 2.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:

--- a/javascript/frameworks/cap/src/qlpack.yml
+++ b/javascript/frameworks/cap/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-cap-queries
-version: 2.2.0
+version: 2.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-cap-models: "^2.2.0"
-  advanced-security/javascript-sap-cap-all: "^2.2.0"
+  advanced-security/javascript-sap-cap-models: "^2.3.0"
+  advanced-security/javascript-sap-cap-all: "^2.3.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/cap/test/qlpack.yml
+++ b/javascript/frameworks/cap/test/qlpack.yml
@@ -1,9 +1,9 @@
 ---
 name: advanced-security/javascript-sap-cap-queries-tests
-version: 2.2.0
+version: 2.3.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-cap-queries: "^2.2.0"
-  advanced-security/javascript-sap-cap-models: "^2.2.0"
-  advanced-security/javascript-sap-cap-all: "^2.2.0"
+  advanced-security/javascript-sap-cap-queries: "^2.3.0"
+  advanced-security/javascript-sap-cap-models: "^2.3.0"
+  advanced-security/javascript-sap-cap-all: "^2.3.0"

--- a/javascript/frameworks/ui5/ext/qlpack.yml
+++ b/javascript/frameworks/ui5/ext/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-ui5-models
-version: 2.2.0
+version: 2.3.0
 extensionTargets:
   codeql/javascript-all: "^2.4.0"
 dataExtensions:

--- a/javascript/frameworks/ui5/lib/qlpack.yml
+++ b/javascript/frameworks/ui5/lib/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-ui5-all
-version: 2.2.0
+version: 2.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:

--- a/javascript/frameworks/ui5/src/qlpack.yml
+++ b/javascript/frameworks/ui5/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-ui5-queries
-version: 2.2.0
+version: 2.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-ui5-models: "^2.2.0"
-  advanced-security/javascript-sap-ui5-all: "^2.2.0"
+  advanced-security/javascript-sap-ui5-models: "^2.3.0"
+  advanced-security/javascript-sap-ui5-all: "^2.3.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/ui5/test/qlpack.yml
+++ b/javascript/frameworks/ui5/test/qlpack.yml
@@ -1,5 +1,5 @@
 name: advanced-security/javascript-sap-ui5-queries-tests
-version: 2.2.0
+version: 2.3.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
@@ -7,6 +7,6 @@ dependencies:
   # no overlap occurs with the SAP UI5 queries. We therefore allow any version
   # greater than or equal to 1.2.0, as major breaking changes are not a concern.
   codeql/javascript-queries: ">1.2.0"
-  advanced-security/javascript-sap-ui5-queries: "^2.2.0"
-  advanced-security/javascript-sap-ui5-models: "^2.2.0"
-  advanced-security/javascript-sap-ui5-all: "^2.2.0"
+  advanced-security/javascript-sap-ui5-queries: "^2.3.0"
+  advanced-security/javascript-sap-ui5-models: "^2.3.0"
+  advanced-security/javascript-sap-ui5-all: "^2.3.0"

--- a/javascript/frameworks/xsjs/ext/qlpack.yml
+++ b/javascript/frameworks/xsjs/ext/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-xsjs-models
-version: 2.2.0
+version: 2.3.0
 extensionTargets:
   codeql/javascript-all: "^2.4.0"
 dataExtensions:

--- a/javascript/frameworks/xsjs/lib/qlpack.yml
+++ b/javascript/frameworks/xsjs/lib/qlpack.yml
@@ -1,7 +1,7 @@
 ---
 library: true
 name: advanced-security/javascript-sap-xsjs-all
-version: 2.2.0
+version: 2.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:

--- a/javascript/frameworks/xsjs/src/qlpack.yml
+++ b/javascript/frameworks/xsjs/src/qlpack.yml
@@ -1,11 +1,11 @@
 ---
 library: false
 name: advanced-security/javascript-sap-xsjs-queries
-version: 2.2.0
+version: 2.3.0
 suites: codeql-suites
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-xsjs-models: "^2.2.0"
-  advanced-security/javascript-sap-xsjs-all: "^2.2.0"
+  advanced-security/javascript-sap-xsjs-models: "^2.3.0"
+  advanced-security/javascript-sap-xsjs-all: "^2.3.0"
 default-suite-file: codeql-suites/javascript-code-scanning.qls

--- a/javascript/frameworks/xsjs/test/qlpack.yml
+++ b/javascript/frameworks/xsjs/test/qlpack.yml
@@ -1,8 +1,8 @@
 ---
 name: advanced-security/javascript-sap-xsjs-tests
-version: 2.2.0
+version: 2.3.0
 extractor: javascript
 dependencies:
   codeql/javascript-all: "^2.4.0"
-  advanced-security/javascript-sap-xsjs-queries: "^2.2.0"
-  advanced-security/javascript-sap-xsjs-all: "^2.2.0"
+  advanced-security/javascript-sap-xsjs-queries: "^2.3.0"
+  advanced-security/javascript-sap-xsjs-all: "^2.3.0"

--- a/javascript/heuristic-models/ext/qlpack.yml
+++ b/javascript/heuristic-models/ext/qlpack.yml
@@ -2,7 +2,7 @@
 library: true
 warnOnImplicitThis: false
 name: advanced-security/javascript-heuristic-models
-version: 2.2.0
+version: 2.3.0
 extensionTargets:
   codeql/javascript-all: "*"
 dataExtensions:

--- a/javascript/heuristic-models/tests/qlpack.yml
+++ b/javascript/heuristic-models/tests/qlpack.yml
@@ -1,8 +1,8 @@
 library: false
 warnOnImplicitThis: false
 name: advanced-security/javascript-heuristic-models-tests
-version: 2.2.0
+version: 2.3.0
 extractor: javascript
 dependencies:
   "codeql/javascript-all": "*"
-  "advanced-security/javascript-heuristic-models": 2.2.0
+  "advanced-security/javascript-heuristic-models": 2.3.0


### PR DESCRIPTION
## What This PR Contributes

Bump QL packs to 2.3.0. This is for release v2.3.0 in preparation for CLI 2.23.1.

## Future Works

Publish the packs and make a release.
