### PR TITLE
Address deprecation of `DbLocation`

### DIFF
--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/BindingStringParser.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/BindingStringParser.qll
@@ -3,7 +3,7 @@ import javascript as stdlib
 signature class BindingStringReaderSig {
   string getBindingString();
 
-  stdlib::DbLocation getLocation();
+  stdlib::Location getLocation();
 
   // Get a dataflow node associated with the binding string, if any.
   // Note that not all location from which we can obtain a binding string

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/Bindings.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/Bindings.qll
@@ -65,7 +65,7 @@ private class BindingStringReader extends TBindingString {
     )
   }
 
-  DbLocation getLocation() {
+  Location getLocation() {
     exists(StringLiteral stringLiteral |
       this = TBindingStringFromLiteral(stringLiteral) and
       result = stringLiteral.getLocation()


### PR DESCRIPTION
## What This PR Contributes

Replace deprecated `DbLocation` with plain `Location`. [The former is a deprecated alias to the latter](https://github.com/github/codeql/blob/5ad332e37f219caeaab8eeb3188e9160f59376bd/javascript/ql/lib/semmle/javascript/Locations.qll#L153-L156).

## Future Works

N/A
