### PR TITLE
Fix shared flow step LogArgumentToListener

### DIFF
--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5LogsToHttpQuery.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5LogsToHttpQuery.qll
@@ -29,13 +29,7 @@ module UI5LogEntryToHttp implements DataFlow::StateConfigSig {
     UI5LogInjection::isAdditionalFlowStep(start, end) and
     preState = postState
     or
-    inSameWebApp(start.getFile(), end.getFile()) and
-    start =
-      ModelOutput::getATypeNode("SapLogger")
-          .getMember(["debug", "error", "fatal", "info", "trace", "warning"])
-          .getACall()
-          .getAnArgument() and
-    end = ModelOutput::getATypeNode("SapLogEntries").asSource() and
+    stepLogger(start, end) and
     preState = "not-logged-not-accessed" and
     postState = "logged-and-accessed"
   }

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5LogsToHttpQuery.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5LogsToHttpQuery.qll
@@ -29,11 +29,15 @@ module UI5LogEntryToHttp implements DataFlow::StateConfigSig {
     UI5LogInjection::isAdditionalFlowStep(start, end) and
     preState = postState
     or
-    exists(LogArgumentToListener logArgumentToListener |
-      logArgumentToListener.step(start, end) and
-      preState = "not-logged-not-accessed" and
-      postState = "logged-and-accessed"
-    )
+    inSameWebApp(start.getFile(), end.getFile()) and
+    start =
+      ModelOutput::getATypeNode("SapLogger")
+          .getMember(["debug", "error", "fatal", "info", "trace", "warning"])
+          .getACall()
+          .getAnArgument() and
+    end = ModelOutput::getATypeNode("SapLogEntries").asSource() and
+    preState = "not-logged-not-accessed" and
+    postState = "logged-and-accessed"
   }
 
   predicate isSink(DataFlow::Node node, FlowState state) {

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5LogsToHttpQuery.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5LogsToHttpQuery.qll
@@ -29,7 +29,7 @@ module UI5LogEntryToHttp implements DataFlow::StateConfigSig {
     UI5LogInjection::isAdditionalFlowStep(start, end) and
     preState = postState
     or
-    stepLogger(start, end) and
+    logArgumentToListener(start, end) and
     preState = "not-logged-not-accessed" and
     postState = "logged-and-accessed"
   }

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/dataflow/FlowSteps.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/dataflow/FlowSteps.qll
@@ -347,7 +347,7 @@ class ResourceBundleGetTextCallArgToReturnValueStep extends DataFlow::SharedFlow
  * A step from any argument of a SAP logging function to the `onLogEntry`
  * method of a custom log listener in the same application.
  */
-predicate stepLogger(DataFlow::Node start, DataFlow::Node end) {
+predicate logArgumentToListener(DataFlow::Node start, DataFlow::Node end) {
   inSameWebApp(start.getFile(), end.getFile()) and
   start =
     ModelOutput::getATypeNode("SapLogger")
@@ -357,6 +357,12 @@ predicate stepLogger(DataFlow::Node start, DataFlow::Node end) {
   end = ModelOutput::getATypeNode("SapLogEntries").asSource()
 }
 
+/**
+ * A step from any argument of a SAP logging function to the `onLogEntry`
+ * method of a custom log listener in the same application.
+ */
 class LogArgumentToListener extends DataFlow::SharedFlowStep {
-  override predicate step(DataFlow::Node start, DataFlow::Node end) { stepLogger(start, end) }
+  override predicate step(DataFlow::Node start, DataFlow::Node end) {
+    logArgumentToListener(start, end)
+  }
 }

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/dataflow/FlowSteps.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/dataflow/FlowSteps.qll
@@ -342,3 +342,21 @@ class ResourceBundleGetTextCallArgToReturnValueStep extends DataFlow::SharedFlow
     )
   }
 }
+
+/**
+ * A step from any argument of a SAP logging function to the `onLogEntry`
+ * method of a custom log listener in the same application.
+ */
+predicate stepLogger(DataFlow::Node start, DataFlow::Node end) {
+  inSameWebApp(start.getFile(), end.getFile()) and
+  start =
+    ModelOutput::getATypeNode("SapLogger")
+        .getMember(["debug", "error", "fatal", "info", "trace", "warning"])
+        .getACall()
+        .getAnArgument() and
+  end = ModelOutput::getATypeNode("SapLogEntries").asSource()
+}
+
+class LogArgumentToListener extends DataFlow::SharedFlowStep {
+  override predicate step(DataFlow::Node start, DataFlow::Node end) { stepLogger(start, end) }
+}

--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/dataflow/FlowSteps.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/dataflow/FlowSteps.qll
@@ -342,19 +342,3 @@ class ResourceBundleGetTextCallArgToReturnValueStep extends DataFlow::SharedFlow
     )
   }
 }
-
-/**
- * A step from any argument of a SAP logging function to the `onLogEntry`
- * method of a custom log listener in the same application.
- */
-class LogArgumentToListener extends DataFlow::SharedFlowStep {
-  override predicate step(DataFlow::Node start, DataFlow::Node end) {
-    inSameWebApp(start.getFile(), end.getFile()) and
-    start =
-      ModelOutput::getATypeNode("SapLogger")
-          .getMember(["debug", "error", "fatal", "info", "trace", "warning"])
-          .getACall()
-          .getAnArgument() and
-    end = ModelOutput::getATypeNode("SapLogEntries").asSource()
-  }
-}


### PR DESCRIPTION
over sharing of flow steps was occuring unintentionally

## What This PR Contributes

previously in release 2.1.0 the definition of the additional flow step of the [UI5LogsToHttp.ql](https://github.com/advanced-security/codeql-sap-js/blob/76e084913a3e1a2b44ae817e2961b0dbce755507/javascript/frameworks/ui5/src/UI5LogInjection/UI5LogsToHttp.ql#L9) query had an [inlined implementation of logger access](https://github.com/advanced-security/codeql-sap-js/blob/76e084913a3e1a2b44ae817e2961b0dbce755507/javascript/frameworks/ui5/src/UI5LogInjection/UI5LogsToHttp.ql#L58) , this was then refactored and added into a shared step that had a union result that meant the query unintentionally no longer constrained on going through logging functionality only (which is a requirement of the query)

## Future Works

potentially consider a different, more correct mechanism to allow for sharing of this flow step (if that makes sense) across different situations
