### PR TITLE
Update 'actions/*' versions to latest

### DIFF
--- a/.github/workflows/cds-extractor-dist-bundle.yml
+++ b/.github/workflows/cds-extractor-dist-bundle.yml
@@ -19,10 +19,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/code_scanning.yml
+++ b/.github/workflows/code_scanning.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Prepare local CodeQL model packs
       run: |
@@ -89,7 +89,7 @@ jobs:
 
     - name: Upload sarif change
       if: steps.validate.outcome != 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: sarif
         path: |

--- a/.github/workflows/run-codeql-unit-tests-javascript.yml
+++ b/.github/workflows/run-codeql-unit-tests-javascript.yml
@@ -18,7 +18,7 @@ jobs:
       matrix: ${{ steps.export-unit-test-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install QLT
         id: install-qlt
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install QLT
         id: install-qlt
@@ -78,7 +78,7 @@ jobs:
           qlt query run install-packs
 
       - name: Setup Node.js for CDS compilation
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           cache: 'npm'
@@ -121,7 +121,7 @@ jobs:
           --work-dir $RUNNER_TMP
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results-${{ runner.os }}-${{ matrix.codeql_cli }}-${{ matrix.codeql_standard_library_ident }}
           path: |
@@ -135,7 +135,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install QLT
         id: install-qlt
@@ -146,7 +146,7 @@ jobs:
 
 
       - name: Collect test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
 
       - name: Validate test results
         run: |

--- a/.github/workflows/update-codeql.yml
+++ b/.github/workflows/update-codeql.yml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
         - name: Checkout repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Check latest CodeQL CLI version and update qlt.conf.json
           id: check-version


### PR DESCRIPTION
## What This PR Contributes

This PR updates the the versions used for 'actions/*' to latest available versions in order to avoid/resolve vulnerabilities associated with older versions of the open-source 'actions/*' such as:

- `actions/checkout@v5`
- `actions/download-artifact@v6`
- `actions/setup-node@v6`
- `actions/upload-artifact@v5`

## Future Works

Update/upgrade the versions used in actions workflows for:
- NodeJS (currently using versions `18` and `20`, in different workflows)
- `actions/setup-python@v5` --> `actions/setup-python@v6` (required much newer NodeJS version for `@v6`)
