### PR TITLE
UI5 xml control improvement

### DIFF
--- a/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5View.qll
+++ b/javascript/frameworks/ui5/lib/advanced_security/javascript/frameworks/ui5/UI5View.qll
@@ -684,10 +684,7 @@ class XmlView extends UI5View instanceof XmlFile {
 }
 
 private newtype TUI5Control =
-  TXmlControl(XmlElement control) {
-    control.getFile().getName().matches("%.view.xml") and
-    control.getNamespace().toString().matches("%sap%")
-  } or
+  TXmlControl(XmlElement control) { control.getFile().getName().matches("%.view.xml") } or
   TJsonControl(JsonObject control) {
     exists(JsonView view | control.getParent() = view.getRoot().getPropValue("content"))
   } or


### PR DESCRIPTION
## What This PR Contributes

XML controls are defined in files with known extensions (example in views - the files match view.xml). This PR contributes an improved heuristic to knowing which xml elements are controls. This may improve query performance though will not have any semantic affect on the UI5 modelling.

## Future Works

to contribute an inclusion on controls in fragments (will contribute in a generally more fragment focused PR)
