### PR TITLE
Fix `update-release-version.sh` for explicit pack version updates

### DIFF
--- a/scripts/update-release-version.sh
+++ b/scripts/update-release-version.sh
@@ -258,9 +258,11 @@ update_qlt_config() {
 }
 
 ## Update internal dependency references in a qlpack.yml file
-## e.g., advanced-security/javascript-sap-cap-models: "^2.3.0" -> "^2.4.0"
-## e.g., advanced-security/javascript-sap-cap-models: "^2.3.0" -> "^2.4.0-alpha"
-## and   advanced-security/javascript-heuristic-models: 2.3.0 -> 2.4.0
+## Handles all YAML key-value formats used across qlpack files:
+## e.g., advanced-security/javascript-sap-cap-models: "^2.3.0"  -> "^2.4.0"
+## e.g., advanced-security/javascript-sap-cap-models: "2.3.0"   -> "2.4.0"
+## e.g., "advanced-security/javascript-heuristic-models": "2.3.0" -> ... (quoted key)
+## and   advanced-security/javascript-heuristic-models: 2.3.0    -> 2.4.0
 update_internal_deps() {
   local file="$1"
   local old_version="$2"
@@ -271,11 +273,14 @@ update_internal_deps() {
   escaped_old_version=$(printf '%s' "${old_version}" | sed 's/\./\\./g')
 
   for pack_name in "${INTERNAL_PACKS[@]}"; do
-    # Update quoted caret-prefixed versions: "^X.Y.Z"
-    sed -i.bak "s|${pack_name}: \"\\^${escaped_old_version}\"|${pack_name}: \"^${new_version}\"|g" "${file}"
+    # Update quoted caret-prefixed versions: "^X.Y.Z" (pack name optionally quoted)
+    sed -i.bak "s|\"\\{0,1\\}${pack_name}\"\\{0,1\\}: \"\\^${escaped_old_version}\"|${pack_name}: \"^${new_version}\"|g" "${file}"
     rm -f "${file}.bak"
-    # Update unquoted exact versions: X.Y.Z
-    sed -i.bak "s|${pack_name}: ${escaped_old_version}$|${pack_name}: ${new_version}|g" "${file}"
+    # Update quoted exact versions: "X.Y.Z" (pack name optionally quoted)
+    sed -i.bak "s|\"\\{0,1\\}${pack_name}\"\\{0,1\\}: \"${escaped_old_version}\"|${pack_name}: \"${new_version}\"|g" "${file}"
+    rm -f "${file}.bak"
+    # Update unquoted exact versions: X.Y.Z (pack name optionally quoted)
+    sed -i.bak "s|\"\\{0,1\\}${pack_name}\"\\{0,1\\}: ${escaped_old_version}$|${pack_name}: ${new_version}|g" "${file}"
     rm -f "${file}.bak"
   done
 }


### PR DESCRIPTION
Fixes the update-release-version.sh script to update CodeQL pack dependency versions in sync with CodeQL CLI version when a pack dependency points to an explicit pack version vice a semver range or (greater than) caret.

Fixes the cause of the version mismatch fixed by PR #352.

## What This PR Contributes

Improvements to dependency version updating:

* Enhanced the `update_internal_deps()` function to update dependencies regardless of whether the pack name or version is quoted or unquoted, covering all YAML key-value formats found in `qlpack.yml` files. [[1]](diffhunk://#diff-ae12dab303a993dca71010e2c90343246c7809a560adf371e4b6c4d7fcdf12a9R261-R264) [[2]](diffhunk://#diff-ae12dab303a993dca71010e2c90343246c7809a560adf371e4b6c4d7fcdf12a9L274-R283)
* Updated the documentation/comments to reflect the expanded support for various YAML formats.

## Future Works

<!-- Explain in Markdown bullet points what is OUT OF SCOPE of this PR.
     Also organize them with bullet points in a reasonable of hierarchy. -->
