### PR TITLE
Fix unit test windows workflow file 

### DIFF
--- a/.github/workflows/ql-unit-tests-windows.yml
+++ b/.github/workflows/ql-unit-tests-windows.yml
@@ -35,7 +35,7 @@ jobs:
     name: ${{ matrix.test_suite }}
     runs-on: windows-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         test_suite:
           - cap-models
@@ -292,7 +292,8 @@ jobs:
           name: windows-test-results-${{ matrix.test_suite }}
           path: |
             ${{ runner.temp }}/test-results/
-          if-no-files-found: warn
+	  # No files here would mean there was a test error overall
+          if-no-files-found: error
 
       - name: Upload CAP test artifacts
         if: ${{ always() && (matrix.test_suite == 'cap-models' || matrix.test_suite == 'cap-queries') }}


### PR DESCRIPTION

## What This PR Contributes

Fix :
  * unit test windows workflow file to catch no test results produced as an error - not warning only
  * also change to fail fast true for matrix - no value in running some if one fails


## Future Works

none for this
